### PR TITLE
remove extra defines in radio_buggy_mega which cause warnings

### DIFF
--- a/real_time/arduino_src/radio_buggy_mega/main.cpp
+++ b/real_time/arduino_src/radio_buggy_mega/main.cpp
@@ -11,8 +11,6 @@
 // #include "uart.h"
 #include "system_clock.h"
 
-#define USART0_ENABLED
-#define USART1_ENABLED
 #define BAUD 9600
 
 #define DEBUG_DDR  DDRB


### PR DESCRIPTION
These were moved to the makefile in 2b9f09c045c2278a47295f92372f0f6359943477 but I forgot to remove them from main.c.