### PR TITLE
Update RBSerial.java

### DIFF
--- a/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/serial/RBSerial.java
+++ b/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/serial/RBSerial.java
@@ -21,7 +21,7 @@ public class RBSerial {
 		if(!RBSerialMessage.isValidHeader(header)) {
 			return new RBPair(1, null);
 		}
-		if(buf[start+5] != 0x0A){
+		if(buf[(start+5) % buf.length] != 0x0A){
 			return new RBPair(1, null);
 		}
 		// Parse an int, or fail


### PR DESCRIPTION
It is possible that the end of the message is written on the other side of the ring buffers wrap around. 

This has been tested to show, it does not cause any errors. 
Can someone review the change so that I can pull it in to master