### PR TITLE
Logging fix

### DIFF
--- a/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/main/RobobuggyConfigFile.java
+++ b/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/main/RobobuggyConfigFile.java
@@ -34,6 +34,6 @@ public final class  RobobuggyConfigFile {
 	public static  final String COM_PORT_RBSM = "COM6";
 	
 	// iff false, connect to serial sensors 
-	public static final boolean DATA_PLAY_BACK = true;
+	public static final boolean DATA_PLAY_BACK = false;
 
 }

--- a/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/main/RobobuggyMainFile.java
+++ b/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/main/RobobuggyMainFile.java
@@ -56,12 +56,12 @@ public class RobobuggyMainFile {
                 new RobobuggyLogicNotification("Notification 1", RobobuggyMessageLevel.NOTE);
                 new RobobuggyLogicNotification("Notification 2", RobobuggyMessageLevel.NOTE);
 
-                Thread.sleep(500);
+                Thread.sleep(2000);
 
                 new RobobuggyLogicNotification("Notif 3", RobobuggyMessageLevel.NOTE);
             }
             catch (InterruptedException e) {
-                new RobobuggyLogicNotification("interreupted", RobobuggyMessageLevel.NOTE);
+                new RobobuggyLogicNotification("interrupted", RobobuggyMessageLevel.NOTE);
             }
 		}
 

--- a/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/nodes/sensors/LoggingNode.java
+++ b/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/nodes/sensors/LoggingNode.java
@@ -92,6 +92,10 @@ public class LoggingNode extends BuggyDecoratorNode {
                         new RobobuggyLogicNotification("Error creating new log file!", RobobuggyMessageLevel.EXCEPTION);
                         return;
                     }
+
+                    // we want to clear out old messages every time we start to log
+                    messageQueue.clear();
+
                     keepLogging = true;
                     loggingThread = new LogWriterThread();
                     loggingThread.start();


### PR DESCRIPTION
Previously we accidentally would log any messages since system startup. That behavior is now changed so that we clear out the message queue of any old messages on pressing the 'start' button, ignoring any old messages that are in there.