### PR TITLE
Traceable log messages

### DIFF
--- a/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/main/RobobuggyConfigFile.java
+++ b/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/main/RobobuggyConfigFile.java
@@ -53,7 +53,7 @@ public final class  RobobuggyConfigFile {
 
 
 	// iff false, connect to serial sensors 
-	private static final boolean DATA_PLAY_BACK = true;
+	private static final boolean DATA_PLAY_BACK = false;
 
 	private static String waypointSourceLogFile ="NOT_SET";
 	private static String playBackSourceFile = "NOT_SET";

--- a/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/nodes/sensors/LoggingNode.java
+++ b/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/nodes/sensors/LoggingNode.java
@@ -68,15 +68,7 @@ public class LoggingNode extends BuggyDecoratorNode {
         STOPPED_LOGGING,
     }
 
-    private class TraceableMessage {
-        private Message message;
-        private String topic;
 
-        public TraceableMessage(Message m, String topic) {
-            this.message = m;
-            this.topic = topic;
-        }
-    }
 
     /**
      * Create a new {@link LoggingNode} decorator
@@ -309,8 +301,7 @@ public class LoggingNode extends BuggyDecoratorNode {
                 String topic;
                 try {
                     TraceableMessage traceableMessage = messageQueue.take();
-                    toSort = traceableMessage.message;
-                    topic = traceableMessage.topic;
+                    toSort = traceableMessage.getMessage();
 
                     String msgAsJsonString = messageTranslator.toJson(traceableMessage);
 
@@ -340,10 +331,10 @@ public class LoggingNode extends BuggyDecoratorNode {
                         steeringHits++;
                     } else if(toSort instanceof ImageMessage){
                         imageHits++;
-                    } else {
+                    }// else {
                         //a new kind of message!
 //                        new RobobuggyLogicNotification("New message came in that we aren't tracking", RobobuggyMessageLevel.WARNING);
-                    }
+//                    }
                     fileWriteStream.println("        " + msgAsJsonString + ",");
 
                 } catch (InterruptedException e) {

--- a/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/nodes/sensors/TraceableMessage.java
+++ b/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/nodes/sensors/TraceableMessage.java
@@ -1,0 +1,32 @@
+package com.roboclub.robobuggy.nodes.sensors;
+
+import com.roboclub.robobuggy.ros.Message;
+
+/**
+ * a class that helps keep track of where a message came from, incase multiple publishers use the same type of message
+ */
+class TraceableMessage {
+    private Message message;
+    private String topic;
+
+    public TraceableMessage(Message m, String topic) {
+        this.message = m;
+        this.topic = topic;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+
+    public void setMessage(Message message) {
+        this.message = message;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+}

--- a/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/robots/SimRobot.java
+++ b/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/robots/SimRobot.java
@@ -1,8 +1,11 @@
 package com.roboclub.robobuggy.robots;
 
+import com.roboclub.robobuggy.main.RobobuggyConfigFile;
 import com.roboclub.robobuggy.messages.GpsMeasurement;
 import com.roboclub.robobuggy.nodes.localizers.HighTrustGPSLocalizer;
 import com.roboclub.robobuggy.nodes.planners.WayPointFollowerPlanner;
+import com.roboclub.robobuggy.nodes.sensors.LoggingNode;
+import com.roboclub.robobuggy.ros.NodeChannel;
 import com.roboclub.robobuggy.simulation.SimulatedBuggy;
 import com.roboclub.robobuggy.simulation.SimulatedGPSNode;
 import com.roboclub.robobuggy.simulation.SimulatedImuNode;
@@ -54,6 +57,8 @@ public final class SimRobot extends AbstractRobot{
 		SimulatedBuggy simBuggy = SimulatedBuggy.getInstance();
 		simBuggy.setDx(.1);
 
+		nodeList.add(new LoggingNode(NodeChannel.GUI_LOGGING_BUTTON, RobobuggyConfigFile.LOG_FILE_LOCATION,
+				NodeChannel.getLoggingChannels()));
 		//simBuggy.setDth(1);
 	//	simBuggy.setDth(0.10);
 		


### PR DESCRIPTION
Multiple different publishers are using the same message types, which leads to confusion when looking at the log files. This code includes the topic name with the message.

Note that this version will invalidate all previous log files, am working on a solution that would allow us to keep using previous logs