### PR TITLE
I think that I got ordering of which messages to show wrong

### DIFF
--- a/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/main/RobobuggyLogicNotification.java
+++ b/real_time/surface_src/java_src/Alice/src/main/java/com/roboclub/robobuggy/main/RobobuggyLogicNotification.java
@@ -63,29 +63,29 @@ public class RobobuggyLogicNotification {
 			case EXCEPTION:
 				return true;
 			case WARNING:
-				return false;
+				return true;
 			case NOTE:
-				return false;
+				return true;
 			default:
 				return true;
 			}
 		case WARNING:
 			switch(RobobuggyConfigFile.REPORTING_LEVEL){
 			case EXCEPTION:
-				return true;
+				return false;
 			case WARNING:
 				return true;
 			case NOTE:
-				return false;
+				return true;
 			default:
 				return true;
 			}
 		case NOTE:
 			switch (RobobuggyConfigFile.REPORTING_LEVEL) {
 				case EXCEPTION:
-					return true;
+					return false;
 				case WARNING:
-					return true;
+					return false;
 				case NOTE:
 					return true;		
 				default:


### PR DESCRIPTION
I think that I got ordering of which messages to show wrong. 
Can someone verify this.  An exception should always be visible, a warning should only be visible for warning or note, note should only be visible for notes. 

You also may want to create a new message type for Show No Errors, and Debug.  

This entire search could be made more scalable with a list that is traversed for reporting level