### PR TITLE
Changing servoreceiver to do operations atomically

### DIFF
--- a/real_time/arduino_src/lib_avr/servoreceiver/servoreceiver.cpp
+++ b/real_time/arduino_src/lib_avr/servoreceiver/servoreceiver.cpp
@@ -18,7 +18,8 @@ ServoReceiver::ServoReceiver()
 
 void ServoReceiver::Init(volatile uint8_t *pin_reg,
                          uint8_t pin_num,
-                         uint8_t int_num) {
+                         uint8_t int_num) 
+{
     // save instance information
     receiver_pin_reg_ = pin_reg;
     receiver_pin_num_ = pin_num;
@@ -40,7 +41,8 @@ void ServoReceiver::Init(volatile uint8_t *pin_reg,
     last_timestamp_ = 0; // us
 
     // enable the necessary external interrupt
-    switch(int_num_) {
+    switch(int_num_) 
+    {
         case(0):
             #if defined(INT0)
             EIMSK |= _BV(INT0);
@@ -113,21 +115,26 @@ no arguments
 Catches an incoming edge (up or down) in order to time it. This function should
 should be called by the appropriate ISR() in the top level file.
 */
-void ServoReceiver::OnInterruptReceiver(){
+void ServoReceiver::OnInterruptReceiver()
+{
     uint8_t new_pin_value = (*receiver_pin_reg_) & _BV(receiver_pin_num_);
     unsigned long new_timestamp = micros();
     
-    if (new_pin_value != 0){
+    if (new_pin_value != 0)
+    {
         // record the start of a suspected pulse
         up_switch_time_ = micros();
     }
 
-    else {
+    else 
+    {
         // check that we actually recorded the beginning of this pulse
-        if (up_switch_time_ != 0) {
+        if (up_switch_time_ != 0) 
+        {
             // check pulse width is within normal range
             unsigned long pulse_width = new_timestamp - up_switch_time_;
-            if(pulse_width > k_min_pulse_ && pulse_width < k_max_pulse_) {
+            if(pulse_width > k_min_pulse_ && pulse_width < k_max_pulse_) 
+            {
                 // save ok values
                 rc_value_ = pulse_width;
                 last_timestamp_ = new_timestamp;
@@ -141,19 +148,43 @@ void ServoReceiver::OnInterruptReceiver(){
 /*
 no arguments
 Returns the timestamp of the last successfully received servo pulse in
-microseconds since startup or last overflow.
+microseconds since startup or last overflow.  This operation is atomic
 */
-unsigned long ServoReceiver::GetLastTimestamp() {
-    return last_timestamp_;
+unsigned long ServoReceiver::GetLastTimestamp() 
+{
+    uint8_t oldSREG;
+    unsigned long temp;
+
+    oldSREG = SREG;
+
+    cli();
+    temp = last_timestamp_;
+
+    //Return the register to its original state rather than re-enable interrupts
+    SREG = oldSREG;
+
+    return temp;
 }
 
 
 /*
 no arguments
-Return the last read pulse width in microseconds.
+Return the last read pulse width in microseconds.  This operation is atomic
 */
-unsigned long ServoReceiver::GetPulseWidth() {
-    return rc_value_;
+unsigned long ServoReceiver::GetPulseWidth() 
+{
+    uint8_t oldSREG;
+    unsigned long temp;
+
+    oldSREG = SREG;
+
+    cli();
+    temp = rc_value_;
+
+    //Return the register to its original state rather than re-enable interrupts
+    SREG = oldSREG;
+
+    return temp;
 }
 
 
@@ -162,13 +193,15 @@ no arguments
 Returns the angle measurement of the last read pulse width. As far as I can
 tell, this is an arbitrary scale and has an arbitrary offset.
 */
-int ServoReceiver::GetAngle(){
+int ServoReceiver::GetAngle()
+{
     int ret_val = (int)(rc_value_ - AIL_RIGHTMOST)*3/17; //WHYYYYY
     return ret_val;
 }
 
 
-int ServoReceiver::GetAngleHundredths() {
+int ServoReceiver::GetAngleHundredths() 
+{
   // Scale the received signal into hundredths of a degree
   int value = (int)map(rc_value_,
                        k_offset_rc_in,
@@ -179,7 +212,8 @@ int ServoReceiver::GetAngleHundredths() {
 }
 
 
-void ServoReceiver::PrintDebugInfo(FILE *out_stream){
+void ServoReceiver::PrintDebugInfo(FILE *out_stream)
+{
     fprintf(out_stream, "up_switch_time: %lu\n", up_switch_time_);
     fprintf(out_stream, "last_timestamp: %lu\n", last_timestamp_);
     fprintf(out_stream, "rc_value: %lu\n", rc_value_);

--- a/real_time/arduino_src/radio_buggy_mega/main.cpp
+++ b/real_time/arduino_src/radio_buggy_mega/main.cpp
@@ -528,13 +528,14 @@ int main(void)
 
         // Detect dropped radio conections
         // note: interrupts must be disabled while checking system clock so that
-        //       timestamps are not updated under our feet
-        cli(); //disable interrupts
+        //      timestamps are not updated under our feet.  These
+        //      operations are atomic so we're fine
+
         unsigned long time_now = micros();
         unsigned long time1 = g_steering_rx.GetLastTimestamp();
         unsigned long time2 = g_brake_rx.GetLastTimestamp();
         unsigned long time3 = g_auton_rx.GetLastTimestamp();
-        sei(); //enable interrupts
+
         //RC time deltas
         unsigned long delta1 = time_now - time1;
         unsigned long delta2 = time_now - time2;


### PR DESCRIPTION
Previously we had to disable interrupts when updating timestamp values to prevent any issues.  By making the functions atomic, we're ensuring that these timestamp reads are protected while decreasing the time spent with interrupts disabled.

NOTE: THIS HAS NOT BEEN TESTED YET. Do not merge it in until it has been verified to work as expected on the buggy.