### PR TITLE
Battery voltage reading

### DIFF
--- a/real_time/arduino_src/radio_buggy_mega/main.cpp
+++ b/real_time/arduino_src/radio_buggy_mega/main.cpp
@@ -182,38 +182,14 @@ inline long clamp(long input,
 }
 
 
-void adc_init(void) // copy-pasted from wirin.c l.353
+void adc_init(void) // copy-pasted from wiring.c l.353
 {
-#if defined(ADCSRA)
     // set a2d prescaler so we are inside the desired 50-200 KHz range.
-#if F_CPU >= 16000000 // 16 MHz / 128 = 125 KHz
     sbi(ADCSRA, ADPS2);
     sbi(ADCSRA, ADPS1);
     sbi(ADCSRA, ADPS0);
-#elif F_CPU >= 8000000 // 8 MHz / 64 = 125 KHz
-    sbi(ADCSRA, ADPS2);
-    sbi(ADCSRA, ADPS1);
-    cbi(ADCSRA, ADPS0);
-#elif F_CPU >= 4000000 // 4 MHz / 32 = 125 KHz
-    sbi(ADCSRA, ADPS2);
-    cbi(ADCSRA, ADPS1);
-    sbi(ADCSRA, ADPS0);
-#elif F_CPU >= 2000000 // 2 MHz / 16 = 125 KHz
-    sbi(ADCSRA, ADPS2);
-    cbi(ADCSRA, ADPS1);
-    cbi(ADCSRA, ADPS0);
-#elif F_CPU >= 1000000 // 1 MHz / 8 = 125 KHz
-    cbi(ADCSRA, ADPS2);
-    sbi(ADCSRA, ADPS1);
-    sbi(ADCSRA, ADPS0);
-#else // 128 kHz / 2 = 64 KHz -> This is the closest you can get, the prescaler is 2
-    cbi(ADCSRA, ADPS2);
-    cbi(ADCSRA, ADPS1);
-    sbi(ADCSRA, ADPS0);
-#endif
     // enable a2d conversions
     sbi(ADCSRA, ADEN);
-#endif
 }
 
 int adc_read_blocking(uint8_t pin) // takes less than 28us
@@ -230,8 +206,6 @@ int adc_read_blocking(uint8_t pin) // takes less than 28us
     // channel (low 4 bits).  this also sets ADLAR (left-adjust result)
     // to 0 (the default).
     ADMUX = (1 << 6) | (pin & 0x07);
-
-    //delay(1);
 
     // start the conversion
     sbi(ADCSRA, ADSC);
@@ -683,6 +657,7 @@ int main(void)
         g_rbsm.Send(RBSM_MID_MEGA_AUTON_BRAKE_COMMAND, (long unsigned)brake_cmd_auton_engaged);
         g_rbsm.Send(RBSM_MID_MEGA_AUTON_STATE, (long unsigned)g_is_autonomous);
         g_rbsm.Send(RBSM_MID_MEGA_BATTERY_LEVEL, g_current_voltage);
+        dbg_printf("Voltage battery [mV]: %d \n", g_current_voltage);
         g_rbsm.Send(RBSM_MID_MEGA_STEER_FEEDBACK, steering_feedback_angle);
         g_rbsm.Send(RBSM_MID_ENC_TICKS_RESET, g_encoder_distance.GetTicks());
         g_rbsm.Send(RBSM_MID_MEGA_TIMESTAMP, millis());

--- a/real_time/arduino_src/radio_buggy_mega/main.cpp
+++ b/real_time/arduino_src/radio_buggy_mega/main.cpp
@@ -182,7 +182,7 @@ inline long clamp(long input,
 }
 
 
-void adc_init(void) // copy-pasted from wiring.c l.353
+void adc_init(void) // copy-pasted from wiring.c l.353 (Arduino library)
 {
     // set a2d prescaler so we are inside the desired 50-200 KHz range.
     sbi(ADCSRA, ADPS2);
@@ -192,11 +192,9 @@ void adc_init(void) // copy-pasted from wiring.c l.353
     sbi(ADCSRA, ADEN);
 }
 
-int adc_read_blocking(uint8_t pin) // takes less than 28us
+int adc_read_blocking(uint8_t pin) // takes less than 160us
 {
     uint8_t low, high;
-
-    //if (pin >= 54) pin -= 54; // allow for channel or pin numbers
 
     // the MUX5 bit of ADCSRB selects whether we're reading from channels
     // 0 to 7 (MUX5 low) or 8 to 15 (MUX5 high).

--- a/real_time/arduino_src/radio_buggy_mega/main.cpp
+++ b/real_time/arduino_src/radio_buggy_mega/main.cpp
@@ -655,7 +655,6 @@ int main(void)
         g_rbsm.Send(RBSM_MID_MEGA_AUTON_BRAKE_COMMAND, (long unsigned)brake_cmd_auton_engaged);
         g_rbsm.Send(RBSM_MID_MEGA_AUTON_STATE, (long unsigned)g_is_autonomous);
         g_rbsm.Send(RBSM_MID_MEGA_BATTERY_LEVEL, g_current_voltage);
-        dbg_printf("Voltage battery [mV]: %d \n", g_current_voltage);
         g_rbsm.Send(RBSM_MID_MEGA_STEER_FEEDBACK, steering_feedback_angle);
         g_rbsm.Send(RBSM_MID_ENC_TICKS_RESET, g_encoder_distance.GetTicks());
         g_rbsm.Send(RBSM_MID_MEGA_TIMESTAMP, millis());

--- a/real_time/arduino_src/radio_buggy_mega/main.cpp
+++ b/real_time/arduino_src/radio_buggy_mega/main.cpp
@@ -98,6 +98,8 @@
 #define ENCODER_STEERING_B_PINN PB6
 #define ENCODER_STEERING_PCINT  PCINT0_vect
 
+// Constants obtained by measuring the sensor ADC value as function of
+// applied voltage, scanning the full range and then doing a linear regression
 #define BATTERY_ADC 0 // pin to read battery level from (A0)
 #define BATTERY_ADC_SLOPE  14.683 // in mV, obtained from calibration
 #define BATTERY_ADC_OFFSET 44.359
@@ -192,7 +194,7 @@ void adc_init(void) // copy-pasted from wiring.c l.353 (Arduino library)
     sbi(ADCSRA, ADEN);
 }
 
-int adc_read_blocking(uint8_t pin) // takes less than 160us
+int adc_read_blocking(uint8_t pin) // takes less than 160us, return 0 to 1023
 {
     uint8_t low, high;
 
@@ -603,9 +605,7 @@ int main(void)
             g_errors &= ~_BV(RBSM_EID_AUTON_LOST_SIGNAL);
         }
 
-        // Voltage divider mounted with 24k/12k ohm resistors
-        // Constants obtained through caracterisation of divider and ADC reader
-        // scanning the full range and then doing a linear regression
+        // Reading battery voltage from the voltage 24/12 kOhm divider
         g_current_voltage  = adc_read_blocking(BATTERY_ADC);
         g_current_voltage *= BATTERY_ADC_SLOPE;
         g_current_voltage += BATTERY_ADC_OFFSET;


### PR DESCRIPTION
Corrected the ADC reading code to read the battery voltage

* repaired the `adc_init` and `adc_read_blocking` functions (using code straight from the Wiring.cpp arduino library)
* added a `dbg_printf` for the battery level in the loop
* Calculation of ADC reading to voltage (in mV) done using constants obtained for the exact set-up we have : 
* voltage divider (24k, 12k ohm)
* precise calibration using the exact resistor I soldered together (linear regression)
 
Note on precision
* Voltage value precise within 25mV (8mV is the theoretical max)
* Could potentially be precise to 15mV
* Could go down to 10mV if I re-did the calibration using the set-up in the buggy (soldered resistor, not resistor on a breadboard)
* Below 15mV precision, temperature variation might not be negligible anymore