### PR TITLE
Cleaned up Travis build script

### DIFF
--- a/real_time/surface_src/java_src/Alice/travisStyleCheck.sh
+++ b/real_time/surface_src/java_src/Alice/travisStyleCheck.sh
@@ -10,9 +10,6 @@ export GRADLE_BIN=$GRADLE_HOME/bin
 #sets init value if it is set to false then the script will fail
 true
 
-# for viewing the find bugs error file
- cat real_time/surface_src/java_src/Alice/build/reports/findbugs/main.xml
- cat real_time/surface_src/java_src/Alice/build/reports/tests/index.html
 # for counting the number of lines of java code that we have in alice
 find real_time/surface_src/java_src/Alice/ -name '*.java' | xargs wc -l
 # for ensuring that the only println( is in logic error aka the console is not cluttered with debug info


### PR DESCRIPTION
We had inserted a `cat` of the findbugs report to find out what was going on when we were passing local build but failing Travis, but this should not have ended up in master