### PR TITLE
Updated gitignore to discard vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ Electrical/Transistor/code/lib_avr/rbserialmessages/rbsm_config.h
 real_time/surface_src/java_src/.recommenders/
 real_time/surface_src/java_src/Alice/.classpath
 
-# intellij's nonsense
+# IDE-specific files
 *.eml
 setuptools-19.4.zip
 real_time/surface_src/java_src/.idea
@@ -51,3 +51,4 @@ gradlew
 gradlew.bat
 gradle-wrapper.jar
 *.properties
+*.swp


### PR DESCRIPTION
Due to a recent snafu in #472 we only realized a swap file was checked in because we manually tried to open it. In the GitHub code review tool it's very easy to miss a swap file, so this pull request aims to prevent them from being in the repo in the first place