### PR TITLE
Encoder fix

### DIFF
--- a/Electrical/Transistor/code/lib_avr/encoder/Encoder.h
+++ b/Electrical/Transistor/code/lib_avr/encoder/Encoder.h
@@ -33,9 +33,9 @@ extern "C" void __cxa_pure_virtual();
 class Encoder {
     protected:
         volatile uint8_t errors_;
-        volatile long ticks_;
         volatile uint8_t *pin_a_reg_;
         uint8_t pin_a_num_;
+        volatile long ticks_;
 
     public:
         Encoder();

--- a/Electrical/Transistor/code/lib_avr/encoder/Rotary.cpp
+++ b/Electrical/Transistor/code/lib_avr/encoder/Rotary.cpp
@@ -6,7 +6,7 @@
 
 Rotary::Rotary() {}
 
-uint8_t Rotary::Init() {
+void Rotary::Init() {
     ENCODER_PORT |= _BV(ENCODER_PINN);
     ENCODER_DDR &= ~_BV(ENCODER_PINN);
     EIMSK |= _BV(INT2);

--- a/Electrical/Transistor/code/lib_avr/encoder/Rotary.cpp
+++ b/Electrical/Transistor/code/lib_avr/encoder/Rotary.cpp
@@ -1,38 +1,20 @@
 #include "Rotary.h"
 
+#define ENCODER_DDR  DDRD
+#define ENCODER_PORT PORTD
+#define ENCODER_PINN PD2 // arduino 19
 
 Rotary::Rotary() {}
 
-uint8_t Rotary::Init(volatile uint8_t *pin_a_reg,
-                      uint8_t pin_a_num,
-                      volatile uint8_t *port_reg,
-                      volatile uint8_t *ddr_reg) {
-    // save configuration info
-    pin_a_reg_ = pin_a_reg;
-    pin_a_num_ = pin_a_num;
-
-    // reset state
-    ticks_ = 0;
-    errors_ = 0;
-
-    // setup encoder pin with pullups and interrupt
-    *port_reg |= _BV(pin_a_num);
-    *ddr_reg &= ~_BV(pin_a_num);
-
-    //TODO: Too hard coded.  
-    //Maybe turn into input arguments? However, arg list is getting long...
-    //External interrupt mask register. Enables external interrupt on pin PD2
+uint8_t Rotary::Init() {
+    ENCODER_PORT |= _BV(ENCODER_PINN);
+    ENCODER_DDR &= ~_BV(ENCODER_PINN);
     EIMSK |= _BV(INT2);
-    //External interrupt control register A.  Configures interrupt to be triggered on any edge
     EICRA |= _BV(ISC20);
     EICRA &= ~_BV(ISC21);
-
-    return errors_;
 }
 
 void Rotary::OnInterrupt()
 {
-    cli();
     ticks_++;
-    sei();
 }

--- a/Electrical/Transistor/code/lib_avr/encoder/Rotary.h
+++ b/Electrical/Transistor/code/lib_avr/encoder/Rotary.h
@@ -18,24 +18,14 @@
 #define ENCODER_ALLOW_SINGLE_INT
 
 class Rotary : public Encoder {
-    uint8_t config_;
-    volatile uint8_t *pin_b_reg_;
-    uint8_t pin_b_num_;
-    volatile long ticks_;
-    volatile uint8_t pin_state_last_;
-    volatile uint8_t errors_;
 
     public:
         //Note: the super class's constructor is also called
         Rotary();
 
         /** @brief initialize a single wire encoder */
-        uint8_t Init(volatile uint8_t *pin_a_reg,
-                     uint8_t pin_a_num,
-                     volatile uint8_t *port_addr,
-                     volatile uint8_t *ddr_addr);
+        uint8_t Init();
         /** @brief to be called on interrupt of single wire encoder signal */
-        //void OnInterrupt();
         void OnInterrupt() override;
 };
 

--- a/Electrical/Transistor/code/lib_avr/encoder/Rotary.h
+++ b/Electrical/Transistor/code/lib_avr/encoder/Rotary.h
@@ -24,7 +24,7 @@ class Rotary : public Encoder {
         Rotary();
 
         /** @brief initialize a single wire encoder */
-        uint8_t Init();
+        void Init();
         /** @brief to be called on interrupt of single wire encoder signal */
         void OnInterrupt() override;
 };

--- a/Electrical/Transistor/code/radio_buggy_mega/main.cpp
+++ b/Electrical/Transistor/code/radio_buggy_mega/main.cpp
@@ -74,10 +74,6 @@
 #define STATUS_LIGHT_PINN_RED PH6
 #define STATUS_LIGHT_DDR_RED DDRH
 
-#define ENCODER_DDR  DDRD
-#define ENCODER_PORT PORTD
-#define ENCODER_PIN  PIND
-#define ENCODER_PINN PD2 // arduino 19
 #define ENCODER_INT  INT2_vect
 
 #define ENCODER_STEERING_A_DDR  DDRB
@@ -417,8 +413,8 @@ int main(void) {
     unsigned long auton_brake_last = time_start;
     unsigned long auton_steer_last = time_start;
 
-    g_encoder_distance.Init(&ENCODER_PIN, ENCODER_PINN, &ENCODER_PORT, &ENCODER_DDR);
-    
+    g_encoder_distance.Init();
+
     g_encoder_steering.InitQuad(&ENCODER_STEERING_A_PIN,
                                 ENCODER_STEERING_A_PINN,
                                 &ENCODER_STEERING_B_PIN,

--- a/Electrical/Transistor/code/radio_buggy_mega/main.cpp
+++ b/Electrical/Transistor/code/radio_buggy_mega/main.cpp
@@ -175,15 +175,6 @@ void steer_set_velocity(long target_velocity);
 void steering_set(int angle);
 int8_t steering_center();
 
-// Lights
-void indicator_light_init();
-void voltage_too_low_light();
-void auton_timeout_light();
-void rc_timeout_failure_light();
-void voltage_too_low_light_reset();
-void auton_timeout_light_reset();
-void rc_timeout_failure_light_reset();
-
 // Brakes
 void brake_init();
 void brake_raise();

--- a/Legacy/offline/debugging/rbsm_console.py
+++ b/Legacy/offline/debugging/rbsm_console.py
@@ -39,9 +39,9 @@ def create_bit_to_str(start_of_values, takeout=""):
     dict = {}
     settings_file = None
     try:
-        settings_file = open("../../real_time/rbsm_config.txt")
+        settings_file = open("../../../Common/rbsm_config.txt")
     except:
-        print("Error! Unable to find real_time/rbsm_headers.txt\n")
+        print("Error! Unable to find Common/rbsm_config.txt\n")
         sys.exit(1)
     # when the correct headers found
     headers_found = False

--- a/Legacy/offline/debugging/rbsm_lib.py
+++ b/Legacy/offline/debugging/rbsm_lib.py
@@ -7,7 +7,7 @@ class RBSerialMessage:
 
     def __init__(self, device_path):
         self.RBSM_FOOTER = "\n" # 0x0A
-        self.RBSM_BAUD_RATE = 76800
+        self.RBSM_BAUD_RATE = 57600
         self.RBSM_PACKET_LENGTH = 6
         # packet format: unsigned byte, big-endian signed int, char
         self.RBSM_PACKET_FORMAT = ">Bic"


### PR DESCRIPTION
PR #463 broke the rotary encoder implementation.  This was a result of variable clobbering (super class and inheriting class had the same name variables).  This PR cleans up Rotary.h and Rotary.cpp and also updates the rbsm_console.py.