### PR TITLE
Fixed issue where localizer would output NaN as estimate

### DIFF
--- a/Software/real_time/ROS_RoboBuggy/src/robobuggy/src/transistor/localizer/Localizer.cpp
+++ b/Software/real_time/ROS_RoboBuggy/src/robobuggy/src/transistor/localizer/Localizer.cpp
@@ -19,7 +19,7 @@ void Localizer::Encoder_Callback(const robobuggy::Encoder::ConstPtr &msg)
     double ticks = msg->ticks;
     double dx = ticks - prev_encoder_ticks;
     dx = dx * 0.61 / 7.0;
-    double body_speed = dx / (dt / 1000);
+    double body_speed = dx / (dt / 1000.0);
 
     prev_encoder_time = current_time;
     prev_encoder_ticks = ticks;


### PR DESCRIPTION
Was because the time conversion was done on two ints and expected a number less than 1, which led to a divide-by-0