### PR TITLE
Added relative pathing to source the waypoint files

### DIFF
--- a/Software/real_time/ROS_RoboBuggy/src/robobuggy/CMakeLists.txt
+++ b/Software/real_time/ROS_RoboBuggy/src/robobuggy/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   serial
   geodesy
+  roslib
 )
 
 ## System dependencies are found with CMake's conventions

--- a/Software/real_time/ROS_RoboBuggy/src/robobuggy/include/transistor/controller/Controller.h
+++ b/Software/real_time/ROS_RoboBuggy/src/robobuggy/include/transistor/controller/Controller.h
@@ -6,6 +6,7 @@
 #define ROS_ROBOBUGGY_CONTROLLER_H
 
 #include "ros/ros.h"
+#include <ros/package.h>
 #include <robobuggy/Pose.h>
 #include <robobuggy/Command.h>
 #include <robobuggy/GPS.h>

--- a/Software/real_time/ROS_RoboBuggy/src/robobuggy/scripts/data_map_plot.py
+++ b/Software/real_time/ROS_RoboBuggy/src/robobuggy/scripts/data_map_plot.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import rospy
+import rospkg
 import math
 import json
 import time
@@ -67,8 +68,15 @@ def ground_truth_callback(data):
 def waypoints_publisher():
     waypoints_pub = rospy.Publisher('WAYPOINTS_VIZ',GPSFix, queue_size=10)
 
+    # Get location of waypoint file by getting package path and then moving from there
+    rospack = rospkg.RosPack()
+    robobuggy_path = rospack.get_path("robobuggy");
+    config_file_loc = "/config/waypoints.txt"
+
+    waypoint_file = robobuggy_path + config_file_loc;
+
     # read from waypoints file, parse JSON, publish
-    waypoints = open("/mnt/c/Users/bhai/Documents/RoboBuggy/Software/real_time/ROS_RoboBuggy/src/robobuggy/config/waypoints.txt", 'r')
+    waypoints = open(waypoint_file);
     line = waypoints.readline()
     time.sleep(5)
     while line:

--- a/Software/real_time/ROS_RoboBuggy/src/robobuggy/scripts/sim/full_system_sim.py
+++ b/Software/real_time/ROS_RoboBuggy/src/robobuggy/scripts/sim/full_system_sim.py
@@ -5,6 +5,7 @@
 
 # TODO Currently reports only GPS and encoder, include IMU as well
 import rospy
+import rospkg
 import numpy as np
 import utm
 import math
@@ -119,8 +120,13 @@ def main():
     start_x = 0
     start_y = 0
     start_th = math.radians(250) # TODO calculate based on two waypoints
-    # waypoint_file = rospy.get_param("/{}/waypoint_file".format(NODE_NAME))
-    waypoint_file = "/mnt/c/Users/bhai/Documents/RoboBuggy/Software/real_time/ROS_RoboBuggy/src/robobuggy/config/waypoints.txt"
+
+    # Get location of waypoint file by getting package path and then moving from there
+    rospack = rospkg.RosPack()
+    robobuggy_path = rospack.get_path("robobuggy");
+    config_file_loc = "/config/waypoints.txt"
+
+    waypoint_file = robobuggy_path + config_file_loc;
     with open(waypoint_file) as f:
         first_waypoint_str = f.readline()
         first_waypoint_json = json.loads(first_waypoint_str)

--- a/Software/real_time/ROS_RoboBuggy/src/robobuggy/src/transistor/controller/Controller_Runner.cpp
+++ b/Software/real_time/ROS_RoboBuggy/src/robobuggy/src/transistor/controller/Controller_Runner.cpp
@@ -14,7 +14,10 @@ int main(int argc, char **argv)
 
     std::vector<robobuggy::GPS> waypoints;
 
-    std::ifstream waypoint_stream("src/robobuggy/config/waypoints.txt");
+    std::string package_path = ros::package::getPath("robobuggy");
+    std::string config_path = "/config/waypoints.txt";
+
+    std::ifstream waypoint_stream(package_path + config_path);
     std::string waypoint_str;
     while (std::getline(waypoint_stream, waypoint_str))
     {


### PR DESCRIPTION
`rospack` allows us to load the fully qualified path of the package, and the waypoints file will be in a set location under the package, so this way we don't have to make the waypoints file computer-dependent.

Tested with the system simulator, it seems right