### PR TITLE
Fixed GPS initialization failure mode

### DIFF
--- a/Software/real_time/ROS_RoboBuggy/src/robobuggy/include/transistor/gps/GPS_Broadcaster.h
+++ b/Software/real_time/ROS_RoboBuggy/src/robobuggy/include/transistor/gps/GPS_Broadcaster.h
@@ -19,9 +19,9 @@ public:
     GPS_Broadcaster();
     static const std::string NODE_NAME;
     
-    int read_gps_message();
+    void read_gps_message();
     robobuggy::GPS* parse_tokens(std::string tokens[]);
-    void initialize_hardware();
+    int initialize_hardware();
 
 private:
     ros::NodeHandle nh;

--- a/Software/real_time/ROS_RoboBuggy/src/robobuggy/src/transistor/gps/GPS_Broadcaster.cpp
+++ b/Software/real_time/ROS_RoboBuggy/src/robobuggy/src/transistor/gps/GPS_Broadcaster.cpp
@@ -22,7 +22,7 @@ GPS_Broadcaster::GPS_Broadcaster()
 
 }
 
-void GPS_Broadcaster::initialize_hardware()
+int GPS_Broadcaster::initialize_hardware()
 {
     try
     {
@@ -31,16 +31,18 @@ void GPS_Broadcaster::initialize_hardware()
         serial::Timeout to = serial::Timeout::simpleTimeout(1000);
         gps_serial.setTimeout(to);
         gps_serial.open();
+        return 0;
     }
     catch (serial::IOException e)
     {
         ROS_ERROR_STREAM("Unable to open port");
         ROS_ERROR_STREAM(serial_port);
+        return -1;
     }
 }
 
 //parse ONE NMEA string
-int GPS_Broadcaster::read_gps_message()
+void GPS_Broadcaster::read_gps_message()
 {
     if (gps_serial.available())
     {
@@ -78,8 +80,6 @@ int GPS_Broadcaster::read_gps_message()
             }
         }
     }
-
-    return 0;
 }
 
 robobuggy::GPS* GPS_Broadcaster::parse_tokens(std::string tokens[])

--- a/Software/real_time/ROS_RoboBuggy/src/robobuggy/src/transistor/gps/GPS_Broadcaster_Runner.cpp
+++ b/Software/real_time/ROS_RoboBuggy/src/robobuggy/src/transistor/gps/GPS_Broadcaster_Runner.cpp
@@ -8,15 +8,18 @@ int main(int argc, char **argv)
 {
     ros::init(argc, argv, GPS_Broadcaster::NODE_NAME);
     ros::NodeHandle nh;
+    ros::Rate loop_rate(10); //run at 10 hz
 
     GPS_Broadcaster broadcaster;
-    broadcaster.initialize_hardware();
+    int err = broadcaster.initialize_hardware();
+    if (err) {
+        return err;
+    }
+
     while (ros::ok()) {
-        int result = broadcaster.read_gps_message();
-        if (result)
-        {
-            return result;
-        }
+        broadcaster.read_gps_message();
+        ros::spinOnce();
+        loop_rate.sleep();
     }
 
     return 0;


### PR DESCRIPTION
Currently, if the initial setup for the GPS fails, we only print out the error message and don't crash the node (therefore powering the system down). This fix makes the return values and behaviors consistent with what is supposed to happen should we fail to initially connect with the GPS